### PR TITLE
API: Prepare for Scala Dom Types 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Scala DOM Test Utils_ provides a convenient, type-safe way to assert that a real Javascript DOM node matches a certain description using an extensible DSL.
 
-    "com.raquo" %%% "domtestutils" % "0.2"
+    "com.raquo" %%% "domtestutils" % "0.3"
 
 The types of DOM tags, attributes, properties and styles are provided by [Scala DOM Types](https://github.com/raquo/scala-dom-types), but you don't need to be using that library in your application code, _Scala DOM TestUtils_ can test any DOM node no matter how it was created. 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 enablePlugins(ScalaJSBundlerPlugin)
 
 libraryDependencies ++= Seq(
-  "com.raquo" %%% "domtypes" % "0.2.1",
+  "com.raquo" %%% "domtypes" % "0.2.2-SNAPSHOT",
   "org.scala-js" %%% "scalajs-dom" % "0.9.3",
   "org.scalatest" %%% "scalatest" % "3.0.3"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 enablePlugins(ScalaJSBundlerPlugin)
 
 libraryDependencies ++= Seq(
-  "com.raquo" %%% "domtypes" % "0.2.2-SNAPSHOT",
+  "com.raquo" %%% "domtypes" % "0.3",
   "org.scala-js" %%% "scalajs-dom" % "0.9.3",
   "org.scalatest" %%% "scalatest" % "3.0.3"
 )

--- a/src/main/scala/com/raquo/domtestutils/Utils.scala
+++ b/src/main/scala/com/raquo/domtestutils/Utils.scala
@@ -4,6 +4,7 @@ import scala.util.Random
 
 trait Utils {
 
+  // @TODO[API] this doesn't really belong here
   def randomString(prefix: String = "", length: Int = 5): String = {
     prefix + Random.nextString(length)
   }

--- a/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
@@ -18,7 +18,7 @@ trait RuleImplicits {
     new TestableAttr(attr)
   }
 
-  implicit def makePropTestable[V](prop: Prop[V]): TestableProp[V] = {
+  implicit def makePropTestable[V, DomV](prop: Prop[V, DomV]): TestableProp[V, DomV] = {
     new TestableProp(prop)
   }
 

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableStyle.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableStyle.scala
@@ -2,22 +2,18 @@ package com.raquo.domtestutils.matching
 
 import com.raquo.domtestutils.Utils.repr
 import com.raquo.domtypes.generic.keys.Style
-
 import org.scalajs.dom
 
 import scala.scalajs.js
 
 class TestableStyle[V](val style: Style[V]) extends AnyVal {
 
-  def is(expected: V): Rule = (testNode: ExpectedNode) => {
-    testNode.addCheck(nodeStyleIs(style, expected))
+  def is(expectedValue: V): Rule = (testNode: ExpectedNode) => {
+    testNode.addCheck(nodeStyleIs(expectedValue))
   }
 
-  private def nodeStyleIs(style: Style[V], expectedValue: V)(node: dom.Node): MaybeError = {
-    val maybeActualValue = node.asInstanceOf[js.Dynamic]
-      .selectDynamic("style")
-      .selectDynamic(style.name)
-      .asInstanceOf[js.UndefOr[V]].toOption
+  private[domtestutils] def nodeStyleIs(expectedValue: V)(node: dom.Node): MaybeError = {
+    val maybeActualValue = getStyle(node)
     maybeActualValue match {
       case Some(actualValue) =>
         if (actualValue == expectedValue) {
@@ -30,10 +26,11 @@ class TestableStyle[V](val style: Style[V]) extends AnyVal {
     }
   }
 
-  private def getStyle(element: dom.Element, style: Style[V]): Option[String] = {
-    element.asInstanceOf[js.Dynamic]
+  private[domtestutils] def getStyle(node: dom.Node): Option[V] = {
+    // @TODO[Integrity] Pattern match to dom.html.Element instead, and get style from there
+    node.asInstanceOf[js.Dynamic]
       .selectDynamic("style")
       .selectDynamic(style.name)
-      .asInstanceOf[js.UndefOr[String]].toOption
+      .asInstanceOf[js.UndefOr[V]].toOption
   }
 }

--- a/src/main/scala/com/raquo/domtestutils/matching/package.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/package.scala
@@ -1,6 +1,5 @@
 package com.raquo.domtestutils
 
-// @TODO[SERVER]
 import org.scalajs.dom
 
 package object matching {

--- a/src/main/scala/com/raquo/domtestutils/scalatest/DomEnvSpec.scala
+++ b/src/main/scala/com/raquo/domtestutils/scalatest/DomEnvSpec.scala
@@ -1,7 +1,6 @@
 package com.raquo.domtestutils.scalatest
 
 import com.raquo.domtestutils.{EventSimulator, Utils}
-// @TODO[SERVER]
 import org.scalajs.dom
 import org.scalatest.{FunSpec, Matchers}
 

--- a/src/main/scala/com/raquo/domtestutils/scalatest/MountSpec.scala
+++ b/src/main/scala/com/raquo/domtestutils/scalatest/MountSpec.scala
@@ -5,8 +5,7 @@ import org.scalatest.{Outcome, TestSuite}
 
 trait MountSpec
   extends TestSuite
-  with MountOps
-{
+  with MountOps {
 
   override def doAssert(condition: Boolean, message: String): Unit = {
     assert(condition, message)

--- a/src/test/scala/com/raquo/domtestutils/TestableAttrSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableAttrSpec.scala
@@ -1,0 +1,85 @@
+package com.raquo.domtestutils
+
+import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsTrueFalseStringCodec, IntAsStringCodec, StringAsIsCodec}
+import com.raquo.domtypes.generic.keys.Attr
+import org.scalajs.dom
+
+class TestableAttrSpec extends UnitSpec {
+
+  val href = new Attr("href", StringAsIsCodec)
+  val tabIndex = new Attr("tabindex", IntAsStringCodec)
+  val disabled = new Attr("disabled", BooleanAsAttrPresenceCodec)
+  val contentEditable = new Attr("contenteditable", BooleanAsTrueFalseStringCodec)
+
+  def setAttr[V](el: dom.Element, attr: Attr[V], value: V): Unit = {
+    val domValue = attr.codec.encode(value)
+    if (domValue == null) {
+      el.removeAttribute(attr.name)
+    } else {
+      el.setAttribute(attr.name, domValue)
+    }
+  }
+
+  it("href: standard string attr") {
+    val el = dom.document.createElement("a")
+
+    (href nodeAttrIs None) (el) shouldBe None
+    (href nodeAttrIs Some("http://example.com")) (el) shouldBe Some("Attr `href` is missing, expected \"http://example.com\"")
+
+    setAttr(el, href, "http://example.com")
+    (href nodeAttrIs Some("http://example.com")) (el) shouldBe None
+    (href nodeAttrIs Some("http://expected.com")) (el) shouldBe Some("Attr `href` value is incorrect: actual value \"http://example.com\", expected value \"http://expected.com\"")
+  }
+
+  it ("tabIndex: integer attr") {
+    val el = dom.document.createElement("a")
+
+    (tabIndex nodeAttrIs None) (el) shouldBe None
+    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` is missing, expected 5")
+
+    setAttr(el, tabIndex, 10)
+    (tabIndex nodeAttrIs Some(10)) (el) shouldBe None
+    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` value is incorrect: actual value 10, expected value 5")
+  }
+
+  it ("disabled: boolean-as-presence (absence is the same as false)") {
+    val el = dom.document.createElement("a")
+
+    (disabled nodeAttrIs Some(false)) (el) shouldBe None
+    (disabled nodeAttrIs None) (el) shouldBe None
+    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing, expected true")
+
+    setAttr(el, disabled, true)
+    (disabled nodeAttrIs Some(true)) (el) shouldBe None
+    (disabled nodeAttrIs Some(false)) (el) shouldBe Some("Attr `disabled` value is incorrect: actual value true, expected value false")
+    (disabled nodeAttrIs None) (el) shouldBe Some("Attr `disabled` should not be present: actual value true, expected to be missing")
+
+    setAttr(el, disabled, false)
+    (disabled nodeAttrIs Some(false)) (el) shouldBe None
+    (disabled nodeAttrIs None) (el) shouldBe None
+    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing, expected true")
+  }
+
+  it ("contentEditable: boolean as true/false string attr") {
+    val el = dom.document.createElement("a")
+
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing, expected false")
+    (contentEditable nodeAttrIs None)(el) shouldBe None
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing, expected true")
+
+    setAttr(el, contentEditable, true)
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe None
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` value is incorrect: actual value true, expected value false")
+    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present: actual value true, expected to be missing")
+
+    setAttr(el, contentEditable, false)
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe None
+    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present: actual value false, expected to be missing")
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` value is incorrect: actual value false, expected value true")
+
+    el.removeAttribute(contentEditable.name)
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing, expected false")
+    (contentEditable nodeAttrIs None)(el) shouldBe None
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing, expected true")
+  }
+}

--- a/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
@@ -1,0 +1,79 @@
+package com.raquo.domtestutils
+
+import com.raquo.domtypes.generic.codecs.{BooleanAsIsCodec, IntAsIsCodec, IterableAsSpaceSeparatedStringCodec, StringAsIsCodec}
+import com.raquo.domtypes.generic.keys.Prop
+import org.scalajs.dom
+
+import scala.scalajs.js
+
+class TestablePropSpec extends UnitSpec {
+
+  val href = new Prop("href", StringAsIsCodec)
+  val tabIndex = new Prop("tabIndex", IntAsIsCodec)
+  val disabled = new Prop("disabled", BooleanAsIsCodec)
+  val classNames = new Prop("className", IterableAsSpaceSeparatedStringCodec)
+
+  def setProp[V, DomV](el: dom.Element, prop: Prop[V, DomV], value: V): Unit = {
+    val domValue = prop.codec.encode(value).asInstanceOf[js.Any]
+    el.asInstanceOf[js.Dynamic].updateDynamic(prop.name)(domValue)
+  }
+
+  it ("href: standard string prop") {
+    val el = dom.document.createElement("a").asInstanceOf[dom.html.Anchor]
+
+    (href nodePropIs None) (el) shouldBe None
+    (href nodePropIs Some("http://example.com")) (el) shouldBe Some("Prop `href` is empty or missing, expected \"http://example.com\"")
+
+    setProp(el, href, "http://example.com")
+    // Notice that a slash "/" was added to the URL by the "browser" (well, jsdom in this case)
+    (href nodePropIs Some("http://example.com/")) (el) shouldBe None
+    (href nodePropIs Some("http://expected.com/")) (el) shouldBe Some("Prop `href` value is incorrect: actual value \"http://example.com/\", expected value \"http://expected.com/\"")
+  }
+
+  it ("tabIndex: integer prop") {
+    val el = dom.document.createElement("a")
+
+    // -1 is the default value of tabIndex
+    (tabIndex nodePropIs Some(-1)) (el) shouldBe None
+    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect: actual value -1, expected value 5")
+
+    setProp(el, tabIndex, 10)
+    (tabIndex nodePropIs Some(10)) (el) shouldBe None
+    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect: actual value 10, expected value 5")
+  }
+
+  it ("disabled: boolean prop") {
+    val el = dom.document.createElement("a")
+
+    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` is empty or missing, expected false")
+    (disabled nodePropIs None) (el) shouldBe None
+    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` is empty or missing, expected true")
+
+    setProp(el, disabled, true)
+    (disabled nodePropIs Some(true)) (el) shouldBe None
+    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` value is incorrect: actual value true, expected value false")
+    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty / not present: actual value true, expected to be missing")
+
+    setProp(el, disabled, false)
+    (disabled nodePropIs Some(false)) (el) shouldBe None
+    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty / not present: actual value false, expected to be missing")
+    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` value is incorrect: actual value false, expected value true")
+  }
+
+  it ("classNames: list as string prop") {
+    val el = dom.document.createElement("a")
+
+    (classNames nodePropIs None)(el) shouldBe None
+    (classNames nodePropIs Some(Seq("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing, expected List(foo, bar)")
+
+    setProp(el, classNames, Seq("foo", "bar"))
+    (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe None
+    (classNames nodePropIs Some(List("foo", "bar", "baz")))(el) shouldBe Some("Prop `className` value is incorrect: actual value WrappedArray(foo, bar), expected value List(foo, bar, baz)")
+    (classNames nodePropIs None)(el) shouldBe Some("Prop `className` should be empty / not present: actual value WrappedArray(foo, bar), expected to be missing")
+
+    setProp(el, classNames, Seq())
+    (classNames nodePropIs None)(el) shouldBe None
+    (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing, expected List(foo, bar)")
+  }
+}
+

--- a/src/test/scala/com/raquo/domtestutils/TodoSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TodoSpec.scala
@@ -1,8 +1,0 @@
-package com.raquo.domtestutils
-
-class TodoSpec extends UnitSpec {
-
-  ignore("noop") {
-    true shouldEqual true
-  }
-}

--- a/src/test/scala/com/raquo/domtestutils/UnitSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/UnitSpec.scala
@@ -1,7 +1,9 @@
 package com.raquo.domtestutils
 
+import com.raquo.domtestutils.matching.RuleImplicits
 import org.scalatest.{FunSpec, Matchers}
 
 class UnitSpec
   extends FunSpec
   with Matchers
+  with RuleImplicits


### PR DESCRIPTION
- Use new Scala DOM Types snapshot (publishLocal)
- Use codecs
- Add TestableAttrSpec and TestablePropSpec
- Clean up some old comments