### PR TITLE
2.13 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .idea
 
 .DS_Store
+
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: scala
+jdk:
+  - oraclejdk11
+scala:
+  - 2.11.12
+  - 2.12.10
+  - 2.13.1
+
+cache:
+  yarn: true
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.ivy2/local
+    - $HOME/.sbt/boot/
+    - $HOME/.sbt/launchers/
+
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @raquo

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Scala DOM Test Utils_ provides a convenient, type-safe way to assert that a real Javascript DOM node matches a certain description using an extensible DSL.
 
-    "com.raquo" %%% "domtestutils" % "0.9"
+    "com.raquo" %%% "domtestutils" % "0.9.1"
 
 The types of DOM tags, attributes, properties and styles are provided by [Scala DOM Types](https://github.com/raquo/scala-dom-types), but you don't need to be using that library in your application code, _Scala DOM TestUtils_ can test any DOM node no matter how it was created. 
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ enablePlugins(ScalaJSBundlerPlugin)
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
-  "com.raquo" %%% "domtypes" % "0.9",
-  "org.scalatest" %%% "scalatest" % "3.0.5"
+  "com.raquo" %%% "domtypes" % "0.9.5",
+  "org.scalatest" %%% "scalatest" % "3.0.8"
 )
 
 requiresDOM in Test := true

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ enablePlugins(ScalaJSBundlerPlugin)
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
-  "com.raquo" %%% "domtypes" % "0.9.5",
+  "com.raquo" %%% "domtypes" % "0.9.6",
   "org.scalatest" %%% "scalatest" % "3.0.8"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.29")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.12.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.29")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
 

--- a/release.sbt
+++ b/release.sbt
@@ -4,9 +4,9 @@ normalizedName := "domtestutils"
 
 organization := "com.raquo"
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.5")
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 homepage := Some(url("https://github.com/raquo/scala-dom-testutils"))
 

--- a/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
@@ -68,8 +68,9 @@ class TestablePropSpec extends UnitSpec {
 
     setProp(el, classNames, Seq("foo", "bar"))
     (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe None
-    (classNames nodePropIs Some(List("foo", "bar", "baz")))(el) shouldBe Some("Prop `className` value is incorrect: actual value WrappedArray(foo, bar), expected value List(foo, bar, baz)")
-    (classNames nodePropIs None)(el) shouldBe Some("Prop `className` should be empty / not present: actual value WrappedArray(foo, bar), expected to be missing")
+    // @TODO[Elegance] Scala 2.13 has ArraySeq instead of WrappedArray, so we're making an ugly replace here.
+    (classNames nodePropIs Some(List("foo", "bar", "baz")))(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` value is incorrect: actual value ArraySeq(foo, bar), expected value List(foo, bar, baz)")
+    (classNames nodePropIs None)(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` should be empty / not present: actual value ArraySeq(foo, bar), expected to be missing")
 
     setProp(el, classNames, Seq())
     (classNames nodePropIs None)(el) shouldBe None


### PR DESCRIPTION
There is one failing test; the one that does string checking to assert that the result contains a `WrappedArray`. In Scala 2.13 this string will contain `ArraySeq` instead. Other tests are passing.

I'm not sure if it's worth forking the tests for 2.13 to accommodate for this change. The specific asserts could be rewritten or simply dropped.