### PR TITLE
add string diff to testable attrs and props, sbt update, scala update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ enablePlugins(ScalaJSBundlerPlugin)
 libraryDependencies ++= Seq(
   "com.raquo" %%% "domtypes" % "0.10.0",
   "org.scalatest" %%% "scalatest" % "3.1.1",
+  "app.tulz" %%% "stringdiff" % "0.1.0"
 )
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ enablePlugins(ScalaJSBundlerPlugin)
 libraryDependencies ++= Seq(
   "com.raquo" %%% "domtypes" % "0.10.0",
   "org.scalatest" %%% "scalatest" % "3.1.1",
-  "app.tulz" %%% "stringdiff" % "0.1.0"
+  "app.tulz" %%% "stringdiff" % "0.1.1"
 )
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.8
+sbt.version = 1.4.5

--- a/release.sbt
+++ b/release.sbt
@@ -4,9 +4,9 @@ normalizedName := "domtestutils"
 
 organization := "com.raquo"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.4"
 
-crossScalaVersions := Seq("2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.12.12", "2.13.1")
 
 homepage := Some(url("https://github.com/raquo/scala-dom-testutils"))
 

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableHtmlAttr.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableHtmlAttr.scala
@@ -2,6 +2,7 @@ package com.raquo.domtestutils.matching
 
 import com.raquo.domtypes.generic.keys.HtmlAttr
 import com.raquo.domtestutils.Utils.repr
+import app.tulz.diff.StringDiff
 import org.scalajs.dom
 
 class TestableHtmlAttr[V](val attr: HtmlAttr[V]) extends AnyVal {
@@ -24,7 +25,8 @@ class TestableHtmlAttr[V](val attr: HtmlAttr[V]) extends AnyVal {
             if (actualValue == expectedValue) {
               None
             } else {
-              Some(s"Attr `${attr.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}")
+              val diff = StringDiff(actualValue.toString, expectedValue.toString)
+              Some(s"Attr `${attr.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}. Diff:\n${diff}")
             }
           case (None, Some(expectedValue)) =>
             if (attr.codec.encode(expectedValue) == null) {

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableProp.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableProp.scala
@@ -1,5 +1,6 @@
 package com.raquo.domtestutils.matching
 
+import app.tulz.diff.StringDiff
 import com.raquo.domtestutils.Utils.repr
 import com.raquo.domtypes.generic.keys.Prop
 import org.scalajs.dom
@@ -29,7 +30,8 @@ class TestableProp[V, DomV](val prop: Prop[V, DomV]) extends AnyVal {
           Some(s"Prop `${prop.name}` should be empty / not present: actual value ${repr(actualValue)}, expected to be missing")
         case (Some(actualValue), Some(expectedValue)) =>
           if (actualValue != expectedValue) {
-            Some(s"Prop `${prop.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}")
+            val diff = StringDiff(actualValue.toString, expectedValue.toString)
+            Some(s"Prop `${prop.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}. Diff:\n${diff}")
           } else {
             None
           }

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
@@ -1,5 +1,6 @@
 package com.raquo.domtestutils.matching
 
+import app.tulz.diff.StringDiff
 import com.raquo.domtestutils.Utils.repr
 import com.raquo.domtypes.generic.keys.SvgAttr
 import org.scalajs.dom
@@ -25,7 +26,8 @@ class TestableSvgAttr[V](val svgAttr: SvgAttr[V]) extends AnyVal {
             if (actualValue == expectedValue) {
               None
             } else {
-              Some(s"SVG Attr `${svgAttr.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}")
+              val diff = StringDiff(actualValue.toString, expectedValue.toString)
+              Some(s"SVG Attr `${svgAttr.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}. Diff:\n${diff}")
             }
           case (None, Some(expectedValue)) =>
             if (svgAttr.codec.encode(expectedValue) == null) {


### PR DESCRIPTION
Introduced https://github.com/tulz-app/stringdiff into `TestableHtmlAttr`, `TestableProp` and `TestableSvgAttr`.

Output looks like this:

![image](https://user-images.githubusercontent.com/919230/102704204-edee5a00-4280-11eb-8d6d-4d562be57c43.png)
