### PR TITLE
Next: v0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 _Scala DOM Test Utils_ provides a convenient, type-safe way to assert that a real Javascript DOM node matches a certain description using an extensible DSL.
 
-    "com.raquo" %%% "domtestutils" % "0.12.0"  // Scala.js 1.x only
-    "com.raquo" %%% "domtestutils" % "0.10.1"  // Scala.js 0.6.x only
+    "com.raquo" %%% "domtestutils" % "0.13.0"  // Scala.js 1.x only
 
 The types of DOM tags, attributes, properties and styles are provided by [Scala DOM Types](https://github.com/raquo/scala-dom-types), but you don't need to be using that library in your application code, _Scala DOM TestUtils_ can test any DOM node no matter how it was created. 
 
@@ -30,17 +29,17 @@ mount(jsDomNode, "optional clue to show on failure")
  
 // Assert that the mounted node matches the provided description (this test will pass given the input above)
 expectNode(
-  div like(
+  div.of(
     rel is "yolo", // Ensure that rel attribute is "yolo". Note: assertions for properties and styles work similarly 
-    span like "Hello, ", // Ensure the this element contains just one text node: "Hello, "
-    p like (
+    span.of("Hello, "), // Ensure the this element contains just one text node: "Hello, "
+    p.of(
       "bizzare ",
-      a like (
+      a.of(
         href is "http://y2017.com",
         title.isEmpty, // Ensure that title attribute is not set
         "2017"
       ),
-      span like " world"
+      span.of(" world")
     ),
     hr // Just check existence of element and tag name. Equivalent to `hr like ()` 
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,19 @@
 enablePlugins(ScalaJSBundlerPlugin)
 
 libraryDependencies ++= Seq(
-  "com.raquo" %%% "domtypes" % "0.10.0",
-  "org.scalatest" %%% "scalatest" % "3.1.1",
+  "com.raquo" %%% "domtypes" % "0.11.0",
+  "org.scalatest" %%% "scalatest" % "3.2.2",
 )
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 
-version in installJsdom := "16.2.0"
-
 requireJsDomEnv in Test := true
+
+version in installJsdom := "16.4.0"
 
 useYarn := true
 
 parallelExecution in Test := false
-
-version in installJsdom := "16.4.0"
 
 scalaJSLinkerConfig in (Compile, fastOptJS) ~= { _.withSourceMap(false) }
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ requireJsDomEnv in Test := true
 
 useYarn := true
 
+parallelExecution in Test := false
+
 scalaJSLinkerConfig in (Compile, fastOptJS) ~= { _.withSourceMap(false) }
 
 scalaJSLinkerConfig in (Compile, fullOptJS) ~= { _.withSourceMap(false) }

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ useYarn := true
 
 parallelExecution in Test := false
 
+version in installJsdom := "16.4.0"
+
 scalaJSLinkerConfig in (Compile, fastOptJS) ~= { _.withSourceMap(false) }
 
 scalaJSLinkerConfig in (Compile, fullOptJS) ~= { _.withSourceMap(false) }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.8
+sbt.version = 1.4.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.17.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 

--- a/release.sbt
+++ b/release.sbt
@@ -4,9 +4,9 @@ normalizedName := "domtestutils"
 
 organization := "com.raquo"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.4"
 
-crossScalaVersions := Seq("2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.12.12", "2.13.4")
 
 homepage := Some(url("https://github.com/raquo/scala-dom-testutils"))
 

--- a/src/main/scala/com/raquo/domtestutils/EventSimulator.scala
+++ b/src/main/scala/com/raquo/domtestutils/EventSimulator.scala
@@ -41,6 +41,7 @@ trait EventSimulator {
     target.dispatchEvent(evt)
   }
 
+  /** @param eventType e.g. "click" */
   private def simulatePointerEvent(eventType: String, target: dom.Node): Unit = {
     val pointerOpts = new dom.PointerEventInit {
       override val view: js.UndefOr[dom.Window] = dom.window

--- a/src/main/scala/com/raquo/domtestutils/matching/ExpectedNode.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/ExpectedNode.scala
@@ -41,9 +41,13 @@ class ExpectedNode protected (
     expectedChildrenBuffer.append(child)
   }
 
-  def like(rules: Rule*): ExpectedNode = {
-    rules.foreach(rule => rule(this))
+  def of(rules: Rule*): ExpectedNode = {
+    rules.foreach(rule => rule.applyTo(this))
     this
+  }
+
+  def like(rules: Rule*): ExpectedNode = {
+    of(rules: _*)
   }
 
   def checkNodeType(actualNode: dom.Node): MaybeError = {
@@ -106,9 +110,9 @@ object ExpectedNode {
 
   def element(tagName: String): ExpectedNode = new ExpectedNode(maybeTagName = Some(tagName))
 
-  def comment(): ExpectedNode = new ExpectedNode(isComment = true)
+  def comment: ExpectedNode = new ExpectedNode(isComment = true)
 
-  def textNode(): ExpectedNode = new ExpectedNode(isTextNode = true)
+  def textNode: ExpectedNode = new ExpectedNode(isTextNode = true)
 
   def withClue(clue: String, message: String): String = {
     s"[$clue]: $message"

--- a/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
@@ -11,7 +11,7 @@ trait RuleImplicits {
   }
 
   implicit def makeCommentBuilderTestable(commentBuilder: () => Comment): ExpectedNode = {
-    ExpectedNode.comment()
+    ExpectedNode.comment
   }
 
   implicit def makeAttrTestable[V](attr: HtmlAttr[V]): TestableHtmlAttr[V] = {
@@ -48,7 +48,7 @@ trait RuleImplicits {
     if (expectedParent.isComment) {
       expectedParent.addCheck(ExpectedNode.checkCommentText(childText))
     } else {
-      val expectedTextChild = ExpectedNode.textNode()
+      val expectedTextChild = ExpectedNode.textNode
       expectedTextChild.addCheck(ExpectedNode.checkText(childText))
       expectedParent.addExpectedChild(expectedTextChild)
     }

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableStyle.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableStyle.scala
@@ -15,14 +15,22 @@ class TestableStyle[V](val style: Style[V]) extends AnyVal {
   private[domtestutils] def nodeStyleIs(expectedValue: V)(node: dom.Node): MaybeError = {
     val maybeActualValue = getStyle(node)
     maybeActualValue match {
+
       case Some(actualValue) =>
         if (actualValue == expectedValue) {
           None
         } else {
-          Some(s"Style `${style.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}")
+          Some(s"""|Style `${style.name}` value is incorrect:
+                   |- Actual:   ${repr(actualValue)}
+                   |- Expected: ${repr(expectedValue)}
+                   |""".stripMargin)
         }
+
       case None =>
-        Some(s"Style `${style.name}` is completely missing, expected ${repr(expectedValue)}")
+        Some(s"""|Style `${style.name}` is completely missing:
+                 |- Actual:   (style missing)
+                 |- Expected: ${repr(expectedValue)}
+                 |""".stripMargin)
     }
   }
 

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
@@ -16,26 +16,41 @@ class TestableSvgAttr[V](val svgAttr: SvgAttr[V]) extends AnyVal {
 
   private[domtestutils] def nodeSvgAttrIs(maybeExpectedValue: Option[V])(node: dom.Node): MaybeError = {
     node match {
-      // @TODO[Integrity] we can't make a `node instanceof dom.svg.Element` check b/c jsdom does not implement SVGElement
-      case (element: dom.Element) =>
+
+      case (element: dom.svg.Element) =>
         val maybeActualValue = getSvgAttr(element)
         (maybeActualValue, maybeExpectedValue) match {
-          case (None, None) => None
+
           case (Some(actualValue), Some(expectedValue)) =>
             if (actualValue == expectedValue) {
               None
             } else {
-              Some(s"SVG Attr `${svgAttr.name}` value is incorrect: actual value ${repr(actualValue)}, expected value ${repr(expectedValue)}")
+              Some(s"""|SVG Attr `${svgAttr.name}` value is incorrect:
+                       |- Actual:   ${repr(actualValue)}
+                       |- Expected: ${repr(expectedValue)}
+                       |""".stripMargin)
             }
+
           case (None, Some(expectedValue)) =>
             if (svgAttr.codec.encode(expectedValue) == null) {
               None // Note: `encode` returning `null` is exactly how missing attribute values are defined, e.g. in BooleanAsAttrPresenceCodec
             } else {
-              Some(s"SVG Attr `${svgAttr.name}` is missing, expected ${repr(expectedValue)}")
+              Some(s"""|SVG Attr `${svgAttr.name}` is missing:
+                       |- Actual:   (no attribute)
+                       |- Expected: ${repr(expectedValue)}
+                       |""".stripMargin)
             }
+
           case (Some(actualValue), None) =>
-            Some(s"SVG Attr `${svgAttr.name}` should not be present: actual value ${repr(actualValue)}, expected to be missing")
+            Some(s"""|SVG Attr `${svgAttr.name}` should not be present:
+                     |- Actual:   ${repr(actualValue)}
+                     |- Expected: (no attribute)
+                     |""".stripMargin)
+
+          case (None, None) =>
+            None
         }
+
       case _ =>
         Some(s"Unable to verify SVG Attr `${svgAttr.name}` because node $node is not a DOM SVG Element (might be a text node?)")
     }

--- a/src/main/scala/com/raquo/domtestutils/matching/package.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/package.scala
@@ -4,7 +4,11 @@ import org.scalajs.dom
 
 package object matching {
 
-  type Rule = ExpectedNode => Unit
+  trait Rule {
+    // Don't name this `apply`. It would compete with the public ExpectedNode.apply syntax.
+    // This method is only used internally so a lame name is ok
+    def applyTo(node: ExpectedNode): Unit
+  }
 
   type MaybeError = Option[String]
 

--- a/src/test/scala/com/raquo/domtestutils/TestableHtmlAttrSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableHtmlAttrSpec.scala
@@ -24,22 +24,22 @@ class TestableHtmlAttrSpec extends UnitSpec {
     val el = dom.document.createElement("a")
 
     (href nodeAttrIs None) (el) shouldBe None
-    (href nodeAttrIs Some("http://example.com")) (el) shouldBe Some("Attr `href` is missing, expected \"http://example.com\"")
+    (href nodeAttrIs Some("http://example.com")) (el) shouldBe Some("Attr `href` is missing:\n- Actual:   (no attribute)\n- Expected: \"http://example.com\"\n")
 
     setAttr(el, href, "http://example.com")
     (href nodeAttrIs Some("http://example.com")) (el) shouldBe None
-    (href nodeAttrIs Some("http://expected.com")) (el) shouldBe Some("Attr `href` value is incorrect: actual value \"http://example.com\", expected value \"http://expected.com\"")
+    (href nodeAttrIs Some("http://expected.com")) (el) shouldBe Some("Attr `href` value is incorrect:\n- Actual:   \"http://example.com\"\n- Expected: \"http://expected.com\"\n")
   }
 
   it ("tabIndex: integer attr") {
     val el = dom.document.createElement("a")
 
     (tabIndex nodeAttrIs None) (el) shouldBe None
-    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` is missing, expected 5")
+    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` is missing:\n- Actual:   (no attribute)\n- Expected: 5\n")
 
     setAttr(el, tabIndex, 10)
     (tabIndex nodeAttrIs Some(10)) (el) shouldBe None
-    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` value is incorrect: actual value 10, expected value 5")
+    (tabIndex nodeAttrIs Some(5)) (el) shouldBe Some("Attr `tabindex` value is incorrect:\n- Actual:   10\n- Expected: 5\n")
   }
 
   it ("disabled: boolean-as-presence (absence is the same as false)") {
@@ -47,39 +47,39 @@ class TestableHtmlAttrSpec extends UnitSpec {
 
     (disabled nodeAttrIs Some(false)) (el) shouldBe None
     (disabled nodeAttrIs None) (el) shouldBe None
-    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing, expected true")
+    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing:\n- Actual:   (no attribute)\n- Expected: true\n")
 
     setAttr(el, disabled, true)
     (disabled nodeAttrIs Some(true)) (el) shouldBe None
-    (disabled nodeAttrIs Some(false)) (el) shouldBe Some("Attr `disabled` value is incorrect: actual value true, expected value false")
-    (disabled nodeAttrIs None) (el) shouldBe Some("Attr `disabled` should not be present: actual value true, expected to be missing")
+    (disabled nodeAttrIs Some(false)) (el) shouldBe Some("Attr `disabled` value is incorrect:\n- Actual:   true\n- Expected: false\n")
+    (disabled nodeAttrIs None) (el) shouldBe Some("Attr `disabled` should not be present:\n- Actual:   true\n- Expected: (no attribute)\n")
 
     setAttr(el, disabled, false)
     (disabled nodeAttrIs Some(false)) (el) shouldBe None
     (disabled nodeAttrIs None) (el) shouldBe None
-    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing, expected true")
+    (disabled nodeAttrIs Some(true)) (el) shouldBe Some("Attr `disabled` is missing:\n- Actual:   (no attribute)\n- Expected: true\n")
   }
 
   it ("contentEditable: boolean as true/false string attr") {
     val el = dom.document.createElement("a")
 
-    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing, expected false")
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing:\n- Actual:   (no attribute)\n- Expected: false\n")
     (contentEditable nodeAttrIs None)(el) shouldBe None
-    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing, expected true")
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing:\n- Actual:   (no attribute)\n- Expected: true\n")
 
     setAttr(el, contentEditable, true)
     (contentEditable nodeAttrIs Some(true))(el) shouldBe None
-    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` value is incorrect: actual value true, expected value false")
-    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present: actual value true, expected to be missing")
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` value is incorrect:\n- Actual:   true\n- Expected: false\n")
+    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present:\n- Actual:   true\n- Expected: (no attribute)\n")
 
     setAttr(el, contentEditable, false)
     (contentEditable nodeAttrIs Some(false))(el) shouldBe None
-    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present: actual value false, expected to be missing")
-    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` value is incorrect: actual value false, expected value true")
+    (contentEditable nodeAttrIs None)(el) shouldBe Some("Attr `contenteditable` should not be present:\n- Actual:   false\n- Expected: (no attribute)\n")
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` value is incorrect:\n- Actual:   false\n- Expected: true\n")
 
     el.removeAttribute(contentEditable.name)
-    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing, expected false")
+    (contentEditable nodeAttrIs Some(false))(el) shouldBe Some("Attr `contenteditable` is missing:\n- Actual:   (no attribute)\n- Expected: false\n")
     (contentEditable nodeAttrIs None)(el) shouldBe None
-    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing, expected true")
+    (contentEditable nodeAttrIs Some(true))(el) shouldBe Some("Attr `contenteditable` is missing:\n- Actual:   (no attribute)\n- Expected: true\n")
   }
 }

--- a/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
@@ -22,12 +22,12 @@ class TestablePropSpec extends UnitSpec {
     val el = dom.document.createElement("a").asInstanceOf[dom.html.Anchor]
 
     (href nodePropIs None) (el) shouldBe None
-    (href nodePropIs Some("http://example.com")) (el) shouldBe Some("Prop `href` is empty or missing, expected \"http://example.com\"")
+    (href nodePropIs Some("http://example.com")) (el) shouldBe Some("Prop `href` is empty or missing:\n- Actual (raw): \"\"\n- Expected:     \"http://example.com\"\n")
 
     setProp(el, href, "http://example.com")
     // Notice that a slash "/" was added to the URL by the "browser" (well, jsdom in this case)
     (href nodePropIs Some("http://example.com/")) (el) shouldBe None
-    (href nodePropIs Some("http://expected.com/")) (el) shouldBe Some("Prop `href` value is incorrect: actual value \"http://example.com/\", expected value \"http://expected.com/\"")
+    (href nodePropIs Some("http://expected.com/")) (el) shouldBe Some("Prop `href` value is incorrect:\n- Actual:   \"http://example.com/\"\n- Expected: \"http://expected.com/\"\n")
   }
 
   it ("tabIndex: integer prop") {
@@ -35,46 +35,46 @@ class TestablePropSpec extends UnitSpec {
 
     // 0 is the default value of tabIndex
     (tabIndex nodePropIs Some(0)) (el) shouldBe None
-    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect: actual value 0, expected value 5")
+    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect:\n- Actual:   0\n- Expected: 5\n")
 
     setProp(el, tabIndex, 10)
     (tabIndex nodePropIs Some(10)) (el) shouldBe None
-    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect: actual value 10, expected value 5")
+    (tabIndex nodePropIs Some(5)) (el) shouldBe Some("Prop `tabIndex` value is incorrect:\n- Actual:   10\n- Expected: 5\n")
   }
 
   it ("disabled: boolean prop") {
     val el = dom.document.createElement("a")
 
-    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` is empty or missing, expected false")
+    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` is empty or missing:\n- Actual (raw): undefined\n- Expected:     false\n")
     (disabled nodePropIs None) (el) shouldBe None
-    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` is empty or missing, expected true")
+    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` is empty or missing:\n- Actual (raw): undefined\n- Expected:     true\n")
 
     setProp(el, disabled, true)
     (disabled nodePropIs Some(true)) (el) shouldBe None
-    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` value is incorrect: actual value true, expected value false")
-    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty / not present: actual value true, expected to be missing")
+    (disabled nodePropIs Some(false)) (el) shouldBe Some("Prop `disabled` value is incorrect:\n- Actual:   true\n- Expected: false\n")
+    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty or not present:\n- Actual:   true\n- Expected: (empty / not present)\n")
 
     setProp(el, disabled, false)
     (disabled nodePropIs Some(false)) (el) shouldBe None
-    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty / not present: actual value false, expected to be missing")
-    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` value is incorrect: actual value false, expected value true")
+    (disabled nodePropIs None) (el) shouldBe Some("Prop `disabled` should be empty or not present:\n- Actual:   false\n- Expected: (empty / not present)\n")
+    (disabled nodePropIs Some(true)) (el) shouldBe Some("Prop `disabled` value is incorrect:\n- Actual:   false\n- Expected: true\n")
   }
 
   it ("classNames: list as string prop") {
     val el = dom.document.createElement("a")
 
     (classNames nodePropIs None)(el) shouldBe None
-    (classNames nodePropIs Some(Seq("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing, expected List(foo, bar)")
+    (classNames nodePropIs Some(Seq("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing:\n- Actual (raw): \"\"\n- Expected:     List(foo, bar)\n")
 
     setProp(el, classNames, Seq("foo", "bar"))
     (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe None
     // @TODO[Elegance] Scala 2.13 has ArraySeq instead of WrappedArray, so we're making an ugly replace here.
-    (classNames nodePropIs Some(List("foo", "bar", "baz")))(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` value is incorrect: actual value ArraySeq(foo, bar), expected value List(foo, bar, baz)")
-    (classNames nodePropIs None)(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` should be empty / not present: actual value ArraySeq(foo, bar), expected to be missing")
+    (classNames nodePropIs Some(List("foo", "bar", "baz")))(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` value is incorrect:\n- Actual:   ArraySeq(foo, bar)\n- Expected: List(foo, bar, baz)\n")
+    (classNames nodePropIs None)(el).map(_.replace("WrappedArray", "ArraySeq")) shouldBe Some("Prop `className` should be empty or not present:\n- Actual:   ArraySeq(foo, bar)\n- Expected: (empty / not present)\n")
 
     setProp(el, classNames, Seq())
     (classNames nodePropIs None)(el) shouldBe None
-    (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing, expected List(foo, bar)")
+    (classNames nodePropIs Some(List("foo", "bar")))(el) shouldBe Some("Prop `className` is empty or missing:\n- Actual (raw): \"\"\n- Expected:     List(foo, bar)\n")
   }
 }
 

--- a/src/test/scala/com/raquo/domtestutils/TestableSvgAttrSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableSvgAttrSpec.scala
@@ -25,21 +25,21 @@ class TestableSvgAttrSpec extends UnitSpec {
     val el = dom.document.createElementNS(svgNamespaceUri, "svg")
 
     (cls nodeSvgAttrIs None) (el) shouldBe None
-    (cls nodeSvgAttrIs Some("class1")) (el) shouldBe Some("SVG Attr `className` is missing, expected \"class1\"")
+    (cls nodeSvgAttrIs Some("class1")) (el) shouldBe Some("SVG Attr `className` is missing:\n- Actual:   (no attribute)\n- Expected: \"class1\"\n")
 
     setAttr(el, cls, "class1")
     (cls nodeSvgAttrIs Some("class1")) (el) shouldBe None
-    (cls nodeSvgAttrIs Some("class2")) (el) shouldBe Some("SVG Attr `className` value is incorrect: actual value \"class1\", expected value \"class2\"")
+    (cls nodeSvgAttrIs Some("class2")) (el) shouldBe Some("SVG Attr `className` value is incorrect:\n- Actual:   \"class1\"\n- Expected: \"class2\"\n")
   }
 
   it("xlinkHref: namespaced string attr") {
     val el = dom.document.createElementNS(svgNamespaceUri, "svg")
 
     (xlinkHref nodeSvgAttrIs None) (el) shouldBe None
-    (xlinkHref nodeSvgAttrIs Some("http://example.com/1")) (el) shouldBe Some("SVG Attr `xlink:href` is missing, expected \"http://example.com/1\"")
+    (xlinkHref nodeSvgAttrIs Some("http://example.com/1")) (el) shouldBe Some("SVG Attr `xlink:href` is missing:\n- Actual:   (no attribute)\n- Expected: \"http://example.com/1\"\n")
 
     setAttr(el, xlinkHref, "http://example.com/1")
     (xlinkHref nodeSvgAttrIs Some("http://example.com/1")) (el) shouldBe None
-    (xlinkHref nodeSvgAttrIs Some("http://example.com/2")) (el) shouldBe Some("SVG Attr `xlink:href` value is incorrect: actual value \"http://example.com/1\", expected value \"http://example.com/2\"")
+    (xlinkHref nodeSvgAttrIs Some("http://example.com/2")) (el) shouldBe Some("SVG Attr `xlink:href` value is incorrect:\n- Actual:   \"http://example.com/1\"\n- Expected: \"http://example.com/2\"\n")
   }
 }


### PR DESCRIPTION
This will also include Scala DOM Types v0.11.0 once that's released.

Going with simple text error messages for now. API changes:

- Add `of` alias for `like` for brevity: `div.of(span of "text")`
- Make `Rule` into a trait to reduce overloading mess of implicit `apply` methods
- Remove parens from comment and textNode methods on ExpectedNode