### PR TITLE
SDT upgrade – new styles API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 _Scala DOM Test Utils_ provides a convenient, type-safe way to assert that a real Javascript DOM node matches a certain description using an extensible DSL.
 
-    "com.raquo" %%% "domtestutils" % "0.15.1"  // Scala.js 1.7.1+ only
+    "com.raquo" %%% "domtestutils" % "<version>"  // Scala.js 1.7.1+ only
 
 The types of DOM tags, attributes, properties and styles are provided by [Scala DOM Types](https://github.com/raquo/scala-dom-types), but you don't need to be using that library in your application code, _Scala DOM TestUtils_ can test any DOM node no matter how it was created. 
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ libraryDependencies ++= Seq(
 scalacOptions ++= Seq(
   "-deprecation",
   "-feature",
+  "-language:higherKinds",
   "-language:implicitConversions",
   {
     val localSourcesPath = baseDirectory.value.toURI

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,7 +6,7 @@ object Versions {
 
   val Scala_3 = "3.0.2"
 
-  val ScalaDomTypes = "0.15.0"
+  val ScalaDomTypes = "0.15.2-SNAPSHOT"
 
   def ScalaTest: String = "3.2.10"
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -4,11 +4,11 @@ object Versions {
 
   val Scala_2_13 = "2.13.6"
 
-  val Scala_3 = "3.0.2"
+  val Scala_3 = "3.1.0"
 
-  val ScalaDomTypes = "0.15.2-SNAPSHOT"
+  val ScalaDomTypes = "0.16.0-RC1"
 
-  def ScalaTest: String = "3.2.10"
+  val ScalaTest = "3.2.10"
 
   val JsDom = "16.4.0"
 }

--- a/src/main/scala/com/raquo/domtestutils/EventSimulator.scala
+++ b/src/main/scala/com/raquo/domtestutils/EventSimulator.scala
@@ -32,7 +32,7 @@ trait EventSimulator {
 
   def simulateScroll(target: dom.Node): Unit = {
     val scrollOpts = new WheelEventInit {
-      override val view: js.UndefOr[dom.Window] = dom.window
+//      override val view: js.UndefOr[dom.Window] = dom.window  // #TODO scalajs-dom v2.1.0 made this impossible, what now?
     }
     scrollOpts.bubbles = true
     scrollOpts.cancelable = true
@@ -44,7 +44,7 @@ trait EventSimulator {
   /** @param eventType e.g. "click" */
   private def simulatePointerEvent(eventType: String, target: dom.Node): Unit = {
     val pointerOpts = new dom.PointerEventInit {
-      override val view: js.UndefOr[dom.Window] = dom.window
+//      override val view: js.UndefOr[dom.Window] = dom.window  // #TODO scalajs-dom v2.1.0 made this impossible, what now?
     }
     pointerOpts.bubbles = true
     pointerOpts.cancelable = true

--- a/src/main/scala/com/raquo/domtestutils/matching/ExpectedNode.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/ExpectedNode.scala
@@ -1,7 +1,6 @@
 package com.raquo.domtestutils.matching
 
 import com.raquo.domtestutils.Utils.repr
-import com.raquo.domtypes.generic.builders.Tag
 import org.scalajs.dom
 
 import scala.collection.mutable
@@ -105,8 +104,6 @@ class ExpectedNode protected (
 }
 
 object ExpectedNode {
-
-  def element(tag: Tag[_]): ExpectedNode = new ExpectedNode(maybeTagName = Some(tag.name))
 
   def element(tagName: String): ExpectedNode = new ExpectedNode(maybeTagName = Some(tagName))
 

--- a/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/RuleImplicits.scala
@@ -1,40 +1,24 @@
 package com.raquo.domtestutils.matching
 
-import com.raquo.domtypes.generic.builders.Tag
-import com.raquo.domtypes.generic.keys.{HtmlAttr, Prop, Style, SvgAttr}
-import com.raquo.domtypes.generic.nodes.Comment
+trait RuleImplicits[Tag, Comment, Prop[_, _], HtmlAttr[_], SvgAttr[_], Style[_]] {
 
-trait RuleImplicits {
+  implicit def makeTagTestable(tag: Tag): ExpectedNode
 
-  implicit def makeTagTestable(tag: Tag[_]): ExpectedNode = {
-    ExpectedNode.element(tag)
-  }
+  implicit def makeCommentBuilderTestable(commentBuilder: () => Comment): ExpectedNode
 
-  implicit def makeCommentBuilderTestable(commentBuilder: () => Comment): ExpectedNode = {
-    ExpectedNode.comment
-  }
+  implicit def makeAttrTestable[V](attr: HtmlAttr[V]): TestableHtmlAttr[V]
 
-  implicit def makeAttrTestable[V](attr: HtmlAttr[V]): TestableHtmlAttr[V] = {
-    new TestableHtmlAttr(attr)
-  }
+  implicit def makePropTestable[V, DomV](prop: Prop[V, DomV]): TestableProp[V, DomV]
 
-  implicit def makePropTestable[V, DomV](prop: Prop[V, DomV]): TestableProp[V, DomV] = {
-    new TestableProp(prop)
-  }
+  implicit def makeStyleTestable[V](style: Style[V]): TestableStyleProp[V]
 
-  implicit def makeStyleTestable[V](style: Style[V]): TestableStyle[V] = {
-    new TestableStyle(style)
-  }
-
-  implicit def makeSvgAttrTestable[V](svgAttr: SvgAttr[V]): TestableSvgAttr[V] = {
-    new TestableSvgAttr(svgAttr)
-  }
+  implicit def makeSvgAttrTestable[V](svgAttr: SvgAttr[V]): TestableSvgAttr[V]
 
   implicit def expectedNodeAsExpectedChildRule(expectedChild: ExpectedNode): Rule = (expectedParent: ExpectedNode) => {
     expectedParent.addExpectedChild(expectedChild)
   }
 
-  implicit def tagAsExpectedChildRule(tag: Tag[_]): Rule = (expectedParent: ExpectedNode) => {
+  implicit def tagAsExpectedChildRule(tag: Tag): Rule = (expectedParent: ExpectedNode) => {
     val expectedChild: ExpectedNode = makeTagTestable(tag)
     expectedParent.addExpectedChild(expectedChild)
   }

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableHtmlAttr.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableHtmlAttr.scala
@@ -1,10 +1,13 @@
 package com.raquo.domtestutils.matching
 
-import com.raquo.domtypes.generic.keys.HtmlAttr
 import com.raquo.domtestutils.Utils.repr
+import com.raquo.domtypes.generic.codecs.Codec
 import org.scalajs.dom
 
-class TestableHtmlAttr[V](val attr: HtmlAttr[V]) extends AnyVal {
+class TestableHtmlAttr[V](
+  val name: String,
+  val codec: Codec[V, String]
+) {
 
   def is(expectedValue: V): Rule = (testNode: ExpectedNode) => {
     testNode.addCheck(nodeAttrIs(Some(expectedValue)))
@@ -25,24 +28,24 @@ class TestableHtmlAttr[V](val attr: HtmlAttr[V]) extends AnyVal {
             if (actualValue == expectedValue) {
               None
             } else {
-              Some(s"""|Attr `${attr.name}` value is incorrect:
+              Some(s"""|Attr `${name}` value is incorrect:
                        |- Actual:   ${repr(actualValue)}
                        |- Expected: ${repr(expectedValue)}
                        |""".stripMargin)
             }
 
           case (None, Some(expectedValue)) =>
-            if (attr.codec.encode(expectedValue) == null) {
+            if (codec.encode(expectedValue) == null) {
               None // Note: `encode` returning `null` is exactly how missing attribute values are defined, e.g. in BooleanAsAttrPresenceCodec
             } else {
-              Some(s"""|Attr `${attr.name}` is missing:
+              Some(s"""|Attr `${name}` is missing:
                        |- Actual:   (no attribute)
                        |- Expected: ${repr(expectedValue)}
                        |""".stripMargin)
             }
 
           case (Some(actualValue), None) =>
-            Some(s"""|Attr `${attr.name}` should not be present:
+            Some(s"""|Attr `${name}` should not be present:
                      |- Actual:   ${repr(actualValue)}
                      |- Expected: (no attribute)
                      |""".stripMargin)
@@ -52,14 +55,14 @@ class TestableHtmlAttr[V](val attr: HtmlAttr[V]) extends AnyVal {
         }
 
       case _ =>
-        Some(s"Unable to verify Attr `${attr.name}` because node $node is not a DOM HTML Element (might be a text node?)")
+        Some(s"Unable to verify Attr `${name}` because node $node is not a DOM HTML Element (might be a text node?)")
     }
   }
 
   private[domtestutils] def getAttr(element: dom.html.Element): Option[V] = {
     // Note: for boolean-as-presence attributes, this returns `None` instead of `Some(false)` when the attribute is missing.
-    if (element.hasAttribute(attr.name)) {
-      Some(attr.codec.decode(element.getAttribute(attr.name)))
+    if (element.hasAttribute(name)) {
+      Some(codec.decode(element.getAttribute(name)))
     } else {
       None
     }

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableProp.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableProp.scala
@@ -1,14 +1,17 @@
 package com.raquo.domtestutils.matching
 
 import com.raquo.domtestutils.Utils.repr
-import com.raquo.domtypes.generic.keys.Prop
+import com.raquo.domtypes.generic.codecs.Codec
 import org.scalajs.dom
 
 import scala.scalajs.js
 
 // @TODO Create EventPropOps
 
-class TestableProp[V, DomV](val prop: Prop[V, DomV]) extends AnyVal {
+class TestableProp[V, DomV](
+  val name: String,
+  val codec: Codec[V, DomV]
+) {
 
   def is(expectedValue: V): Rule = (testNode: ExpectedNode) => {
     testNode.addCheck(nodePropIs(maybeExpectedValue = Some(expectedValue)))
@@ -27,21 +30,21 @@ class TestableProp[V, DomV](val prop: Prop[V, DomV]) extends AnyVal {
           if (actualValue == expectedValue) {
             None
           } else {
-            Some(s"""|Prop `${prop.name}` value is incorrect:
+            Some(s"""|Prop `${name}` value is incorrect:
                      |- Actual:   ${repr(actualValue)}
                      |- Expected: ${repr(expectedValue)}
                      |""".stripMargin)
           }
 
         case (None, Some(expectedValue)) =>
-          val rawActualValue = node.asInstanceOf[js.Dynamic].selectDynamic(prop.name)
-          Some(s"""|Prop `${prop.name}` is empty or missing:
+          val rawActualValue = node.asInstanceOf[js.Dynamic].selectDynamic(name)
+          Some(s"""|Prop `${name}` is empty or missing:
                    |- Actual (raw): ${repr(rawActualValue)}
                    |- Expected:     ${repr(expectedValue)}
                    |""".stripMargin)
 
         case (Some(actualValue), None) =>
-          Some(s"""|Prop `${prop.name}` should be empty or not present:
+          Some(s"""|Prop `${name}` should be empty or not present:
                    |- Actual:   ${repr(actualValue)}
                    |- Expected: (empty / not present)
                    |""".stripMargin)
@@ -50,19 +53,19 @@ class TestableProp[V, DomV](val prop: Prop[V, DomV]) extends AnyVal {
           None
       }
     } else {
-      Some(s"Unable to verify Prop `${prop.name}` because node $node is not a DOM HTML Element (might be a text node?)")
+      Some(s"Unable to verify Prop `${name}` because node $node is not a DOM HTML Element (might be a text node?)")
     }
   }
 
   private[domtestutils] def getProp(node: dom.Node): Option[V] = {
-    val propValue = node.asInstanceOf[js.Dynamic].selectDynamic(prop.name)
+    val propValue = node.asInstanceOf[js.Dynamic].selectDynamic(name)
     val jsUndef = js.undefined
 
     propValue.asInstanceOf[Any] match {
       case str: String if str.length == 0 => None
       case `jsUndef` => None
       case null => None
-      case _ => Some(prop.codec.decode(propValue.asInstanceOf[DomV]))
+      case _ => Some(codec.decode(propValue.asInstanceOf[DomV]))
     }
   }
 }

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableStyleProp.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableStyleProp.scala
@@ -1,14 +1,13 @@
 package com.raquo.domtestutils.matching
 
 import com.raquo.domtestutils.Utils.repr
-import com.raquo.domtypes.generic.keys.Style
 import org.scalajs.dom
 import org.scalajs.dom.CSSStyleDeclaration
 
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-class TestableStyle[V](val style: Style[V]) extends AnyVal {
+class TestableStyleProp[V](val name: String) {
 
   def is(expectedValue: V | String): Rule = (testNode: ExpectedNode) => {
     // @TODO[Integrity] I hope this toString is ok. We don't use any fancy types for CSS anyway.
@@ -24,14 +23,14 @@ class TestableStyle[V](val style: Style[V]) extends AnyVal {
     } else {
       if (actualValue.nonEmpty) {
         Some(
-          s"""|Style `${style.name}` value is incorrect:
+          s"""|Style `${name}` value is incorrect:
               |- Actual:   ${repr(actualValue)}
               |- Expected: ${repr(expectedValue)}
               |""".stripMargin
         )
       } else {
         Some(
-          s"""|Style `${style.name}` is missing:
+          s"""|Style `${name}` is missing:
               |- Actual:   (style missing, or empty string)
               |- Expected: ${repr(expectedValue)}
               |""".stripMargin
@@ -48,7 +47,7 @@ class TestableStyle[V](val style: Style[V]) extends AnyVal {
       .selectDynamic("style")
       .asInstanceOf[js.UndefOr[CSSStyleDeclaration]]
       .flatMap { css =>
-        css.getPropertyValue(style.name)
+        css.getPropertyValue(name)
       }
       .toOption
       .getOrElse("")

--- a/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
+++ b/src/main/scala/com/raquo/domtestutils/matching/TestableSvgAttr.scala
@@ -1,10 +1,14 @@
 package com.raquo.domtestutils.matching
 
 import com.raquo.domtestutils.Utils.repr
-import com.raquo.domtypes.generic.keys.SvgAttr
+import com.raquo.domtypes.generic.codecs.Codec
 import org.scalajs.dom
 
-class TestableSvgAttr[V](val svgAttr: SvgAttr[V]) extends AnyVal {
+class TestableSvgAttr[V](
+  val name: String,
+  val codec: Codec[V, String],
+  val namespace: Option[String]
+) {
 
   def is(expectedValue: V): Rule = (testNode: ExpectedNode) => {
     testNode.addCheck(nodeSvgAttrIs(Some(expectedValue)))
@@ -25,24 +29,24 @@ class TestableSvgAttr[V](val svgAttr: SvgAttr[V]) extends AnyVal {
             if (actualValue == expectedValue) {
               None
             } else {
-              Some(s"""|SVG Attr `${svgAttr.name}` value is incorrect:
+              Some(s"""|SVG Attr `${name}` value is incorrect:
                        |- Actual:   ${repr(actualValue)}
                        |- Expected: ${repr(expectedValue)}
                        |""".stripMargin)
             }
 
           case (None, Some(expectedValue)) =>
-            if (svgAttr.codec.encode(expectedValue) == null) {
+            if (codec.encode(expectedValue) == null) {
               None // Note: `encode` returning `null` is exactly how missing attribute values are defined, e.g. in BooleanAsAttrPresenceCodec
             } else {
-              Some(s"""|SVG Attr `${svgAttr.name}` is missing:
+              Some(s"""|SVG Attr `${name}` is missing:
                        |- Actual:   (no attribute)
                        |- Expected: ${repr(expectedValue)}
                        |""".stripMargin)
             }
 
           case (Some(actualValue), None) =>
-            Some(s"""|SVG Attr `${svgAttr.name}` should not be present:
+            Some(s"""|SVG Attr `${name}` should not be present:
                      |- Actual:   ${repr(actualValue)}
                      |- Expected: (no attribute)
                      |""".stripMargin)
@@ -52,23 +56,23 @@ class TestableSvgAttr[V](val svgAttr: SvgAttr[V]) extends AnyVal {
         }
 
       case _ =>
-        Some(s"Unable to verify SVG Attr `${svgAttr.name}` because node $node is not a DOM SVG Element (might be a text node?)")
+        Some(s"Unable to verify SVG Attr `${name}` because node $node is not a DOM SVG Element (might be a text node?)")
     }
   }
 
   private[domtestutils] def getSvgAttr(element: dom.Element): Option[V] = {
     // Note: for boolean-as-presence attributes, this returns `None` instead of `Some(false)` when the attribute is missing.
-    if (element.hasAttributeNS(namespaceURI = svgAttr.namespace.orNull, localName = localName)) {
-      Some(svgAttr.codec.decode(element.getAttributeNS(namespaceURI = svgAttr.namespace.orNull, localName = localName)))
+    if (element.hasAttributeNS(namespaceURI = namespace.orNull, localName = localName)) {
+      Some(codec.decode(element.getAttributeNS(namespaceURI = namespace.orNull, localName = localName)))
     } else {
       None
     }
   }
 
   private[domtestutils] def localName: String = {
-    val nsPrefixLength = svgAttr.name.indexOf(':')
+    val nsPrefixLength = name.indexOf(':')
     if (nsPrefixLength > -1) {
-      svgAttr.name.substring(nsPrefixLength + 1)
-    } else svgAttr.name
+      name.substring(nsPrefixLength + 1)
+    } else name
   }
 }

--- a/src/test/scala/com/raquo/domtestutils/TestableHtmlAttrSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableHtmlAttrSpec.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtestutils
 
+import com.raquo.domtestutils.fixtures.HtmlAttr
 import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsTrueFalseStringCodec, IntAsStringCodec, StringAsIsCodec}
-import com.raquo.domtypes.generic.keys.{HtmlAttr}
 import org.scalajs.dom
 
 class TestableHtmlAttrSpec extends UnitSpec {

--- a/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestablePropSpec.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtestutils
 
 import com.raquo.domtypes.generic.codecs.{BooleanAsIsCodec, IntAsIsCodec, IterableAsSpaceSeparatedStringCodec, StringAsIsCodec}
-import com.raquo.domtypes.generic.keys.Prop
+import com.raquo.domtestutils.fixtures.Prop
 import org.scalajs.dom
 
 import scala.scalajs.js

--- a/src/test/scala/com/raquo/domtestutils/TestableStyleSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableStyleSpec.scala
@@ -1,6 +1,6 @@
 package com.raquo.domtestutils
 
-import com.raquo.domtypes.generic.keys.Style
+import com.raquo.domtestutils.fixtures.StyleProp
 import org.scalajs.dom
 import org.scalajs.dom.CSSStyleDeclaration
 
@@ -8,10 +8,10 @@ import scala.scalajs.js
 
 class TestableStyleSpec extends UnitSpec {
 
-  val backgroundColor = new Style[String]("background-color")
-  val zIndex = new Style[Int]("z-index")
+  val backgroundColor = new StyleProp[String]("background-color")
+  val zIndex = new StyleProp[Int]("z-index")
 
-  def setStyle[V](el: dom.Element, style: Style[V], value: V): Unit = {
+  def setStyle[V](el: dom.Element, style: StyleProp[V], value: V): Unit = {
     el.asInstanceOf[js.Dynamic]
       .selectDynamic("style")
       .asInstanceOf[js.UndefOr[CSSStyleDeclaration]]

--- a/src/test/scala/com/raquo/domtestutils/TestableSvgAttrSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/TestableSvgAttrSpec.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtestutils
 
 import com.raquo.domtypes.generic.codecs.StringAsIsCodec
-import com.raquo.domtypes.generic.keys.SvgAttr
+import com.raquo.domtestutils.fixtures.SvgAttr
 import org.scalajs.dom
 
 class TestableSvgAttrSpec extends UnitSpec {

--- a/src/test/scala/com/raquo/domtestutils/UnitSpec.scala
+++ b/src/test/scala/com/raquo/domtestutils/UnitSpec.scala
@@ -1,8 +1,34 @@
 package com.raquo.domtestutils
 
-import com.raquo.domtestutils.matching.RuleImplicits
+import com.raquo.domtestutils.fixtures.{Comment, HtmlAttr, Prop, StyleProp, SvgAttr, Tag}
+import com.raquo.domtestutils.matching.{ExpectedNode, RuleImplicits, TestableHtmlAttr, TestableProp, TestableStyleProp, TestableSvgAttr}
 import com.raquo.domtestutils.scalatest.Matchers
 import org.scalatest.funspec.AnyFunSpec
 
-class UnitSpec extends AnyFunSpec with Matchers with RuleImplicits
+class UnitSpec extends AnyFunSpec with Matchers with RuleImplicits[Tag[Any], Comment, Prop, HtmlAttr, SvgAttr, StyleProp] {
+
+  override implicit def makeTagTestable(tag: Tag[Any]): ExpectedNode = {
+    ExpectedNode.element(tag.name)
+  }
+
+  override implicit def makeCommentBuilderTestable(commentBuilder: () => Comment): ExpectedNode = {
+    ExpectedNode.comment
+  }
+
+  override implicit def makeAttrTestable[V](attr: HtmlAttr[V]): TestableHtmlAttr[V] = {
+    new TestableHtmlAttr[V](attr.name, attr.codec)
+  }
+
+  override implicit def makePropTestable[V, DomV](prop: Prop[V, DomV]): TestableProp[V, DomV] = {
+    new TestableProp[V, DomV](prop.name, prop.codec)
+  }
+
+  override implicit def makeStyleTestable[V](style: StyleProp[V]): TestableStyleProp[V] = {
+    new TestableStyleProp[V](style.name)
+  }
+
+  override implicit def makeSvgAttrTestable[V](svgAttr: SvgAttr[V]): TestableSvgAttr[V] = {
+    new TestableSvgAttr[V](svgAttr.name, svgAttr.codec, svgAttr.namespace)
+  }
+}
 

--- a/src/test/scala/com/raquo/domtestutils/fixtures/Comment.scala
+++ b/src/test/scala/com/raquo/domtestutils/fixtures/Comment.scala
@@ -1,0 +1,3 @@
+package com.raquo.domtestutils.fixtures
+
+class Comment {}

--- a/src/test/scala/com/raquo/domtestutils/fixtures/Key.scala
+++ b/src/test/scala/com/raquo/domtestutils/fixtures/Key.scala
@@ -1,0 +1,13 @@
+package com.raquo.domtestutils.fixtures
+
+import com.raquo.domtypes.generic.codecs.Codec
+
+trait Key { val name: String }
+
+class Prop[V, DomV] (override val name: String, val codec: Codec[V, DomV]) extends Key
+
+class HtmlAttr[V] (override val name: String, val codec: Codec[V, String]) extends Key
+
+class SvgAttr[V] (override val name: String, val codec: Codec[V, String], val namespace: Option[String]) extends Key
+
+class StyleProp[V] (override val name: String) extends Key

--- a/src/test/scala/com/raquo/domtestutils/fixtures/Tag.scala
+++ b/src/test/scala/com/raquo/domtestutils/fixtures/Tag.scala
@@ -1,0 +1,6 @@
+package com.raquo.domtestutils.fixtures
+
+class Tag[+Element](
+  val name: String,
+  val void: Boolean
+)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.15.1"
+ThisBuild / version := "0.15.2-SNAPSHOT"


### PR DESCRIPTION
Upgrade for https://github.com/raquo/scala-dom-types/pull/75

For migration, see the relevant `test` files in the corresponding Laminar commit: https://github.com/raquo/Laminar/commit/0329c3d75dfe66489ce01aa669e1b8730f13581c